### PR TITLE
Fixes #36490 - Remove redundant ERB closing tag in coreos template

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/coreos_provision.erb
+++ b/app/views/unattended/provisioning_templates/provision/coreos_provision.erb
@@ -11,7 +11,6 @@ description: |
   Provisioning template for the CoreOS Container Linux distribution.
   This does not work for Fedora CoreOS or Flatcar Container Linux, which use Ignition instead.
 -%>
-%>
 <%- if host_param('ignition_template') -%>
 <%= host_param('ignition_template') %>
 <%- else -%>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
